### PR TITLE
mapstruct gradle 적용

### DIFF
--- a/your-delivery/build.gradle
+++ b/your-delivery/build.gradle
@@ -20,9 +20,13 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.mapstruct:mapstruct:1.5.5.Final'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
 	annotationProcessor 'org.projectlombok:lombok'
+	annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
+
 	runtimeOnly 'com.h2database:h2'
 	compileOnly 'org.projectlombok:lombok'
 }


### PR DESCRIPTION
## 관련된 이슈 번호
- issue : #46 

## 변경사항 (할 일)
1. mapstruct를 gradle에 적용한다.
(이후 사용법 : Object간의 변환이 필요한 브랜치마다 mapsturct를 적용하여 개발해 나간다.)
